### PR TITLE
clone-disks.sh: script to clone disks locally

### DIFF
--- a/clone-disks.sh
+++ b/clone-disks.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Clone PCjs disk image repositories locally
+set -ue
+
+clone_repo() {
+	mkdir -p "$1"
+	if ! test -d "$1/$2/.git"; then
+		git clone "https://github.com/jeffpar/pcjs-$2.git" "$1/$2"
+	fi
+}
+
+cd "$(dirname "$0")"
+mkdir -p disks
+clone_repo disks diskettes
+clone_repo disks gamedisks
+clone_repo disks miscdisks
+clone_repo disks pcsigdisks
+
+# Below disabled for now, repos publicly unavailable
+# clone_repo cdroms cds001
+# clone_repo cdroms cds002
+# clone_repo cdroms cds005


### PR DESCRIPTION
Adds a shell script to automate the task in the PCjs wiki section [Using a Local Web Server: Accessing Disk Images Locally](https://github.com/jeffpar/pcjs/wiki/Using-a-Local-Web-Server#accessing-disk-images-locally)

If this PR is accepted, then those instructions can be simplified to just running this script

I commented out the steps to clone the CD-ROM repos since they do not appear to be publicly available, see #113 – if they end up being made publicly accessible, then those steps can be uncommented